### PR TITLE
Removing provisioner tag

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,5 +1,3 @@
-data "aws_caller_identity" "current" {}
-
 data "aws_ami" "amazon_linux_ecs" {
   most_recent = true
 

--- a/locals.tf
+++ b/locals.tf
@@ -19,7 +19,6 @@ locals {
       "${var.organization}:billing:product"     = var.product
       "${var.organization}:billing:environment" = var.environment
       creator                                   = local.creator
-      provisioner                               = data.aws_caller_identity.current.user_id
       repo                                      = var.repo
     }
   )


### PR DESCRIPTION
This tag doesn't help much, and causes issues with dependencies updating in weird orders.